### PR TITLE
Update BackhedF_2015_metadata.tsv

### DIFF
--- a/inst/curated/BackhedF_2015/BackhedF_2015_metadata.tsv
+++ b/inst/curated/BackhedF_2015/BackhedF_2015_metadata.tsv
@@ -97,7 +97,7 @@ SID608_M	SID608_mo	stool	NA	control	healthy	NA	NA	adult	female	SWE	no	NA	2597430
 SID282_B	SID282	stool	no	control	healthy	NA	3	newborn	male	SWE	no	0	25974306	NA	NA	80	100	IlluminaHiSeq	no	26	child	vaginal	exclusively_breastfeeding	Valentina_Giunchiglia|Marisa_Metzger	ERR525838
 SID282_4M	SID282	stool	no	control	healthy	NA	131	newborn	male	SWE	no	128	25974306	NA	NA	80	100	IlluminaHiSeq	no	26	child	vaginal	exclusively_breastfeeding	Valentina_Giunchiglia|Marisa_Metzger	ERR525837
 SID282_12M	SID282	stool	no	control	healthy	NA	378	child	male	SWE	no	375	25974306	NA	NA	80	100	IlluminaHiSeq	no	26	child	vaginal	no_breastfeeding	Valentina_Giunchiglia|Marisa_Metzger	ERR525836
-SID282_M	SID282_mo	stool	NA	control	healthy	NA	NA  adult	female	SWE	no	NA	25974306	NA	NA	80	100	IlluminaHiSeq	yes	26	mother	NA	NA	Valentina_Giunchiglia|Marisa_Metzger	ERR525839
+SID282_M	SID282_mo	stool	NA	control	healthy	NA	NA adult female	SWE	no	NA	25974306	NA	NA	80	100	IlluminaHiSeq	yes	26	mother	NA	NA	Valentina_Giunchiglia|Marisa_Metzger	ERR525839
 SID70_B	SID70	stool	no	control	healthy	NA	2	newborn	male	SWE	no	0	25974306	56218302	5608724010	80	100	IlluminaHiSeq	no	27	child	vaginal	exclusively_breastfeeding	Valentina_Giunchiglia	ERR526066
 SID70_4M	SID70	stool	yes	control	healthy	NA	120	newborn	male	SWE	no	118	25974306	44241624	4405307590	80	100	IlluminaHiSeq	no	27	child	vaginal	mixed_feeding	Valentina_Giunchiglia	ERR526065
 SID70_12M	SID70	stool	yes	control	healthy	NA	365	child	male	SWE	no	363	25974306	54561744	5443169430	80	100	IlluminaHiSeq	no	27	child	vaginal	no_breastfeeding	Valentina_Giunchiglia	ERR526064

--- a/inst/curated/BackhedF_2015/BackhedF_2015_metadata.tsv
+++ b/inst/curated/BackhedF_2015/BackhedF_2015_metadata.tsv
@@ -94,10 +94,10 @@ SID608_B	SID608	stool	no	control	healthy	NA	8	newborn	female	SWE	no	0	25974306	2
 SID608_4M	SID608	stool	no	control	healthy	NA	127	newborn	female	SWE	no	119	25974306	34834636	3472465960	80	100	IlluminaHiSeq	no	25	child	c_section	exclusively_breastfeeding	Valentina_Giunchiglia	ERR526029
 SID608_12M	SID608	stool	no	control	healthy	NA	374	child	female	SWE	no	366	25974306	32737764	3266963890	80	100	IlluminaHiSeq	no	25	child	c_section	any_breastfeeding	Valentina_Giunchiglia	ERR526028
 SID608_M	SID608_mo	stool	NA	control	healthy	NA	NA	adult	female	SWE	no	NA	25974306	34593178	3454133020	80	100	IlluminaHiSeq	yes	25	mother	NA	NA	Valentina_Giunchiglia	ERR526031
-SID367_B	SID367	stool	no	control	healthy	NA	3	newborn	male	SWE	no	0	25974306	32727538	3264384820	80	100	IlluminaHiSeq	no	26	child	vaginal	exclusively_breastfeeding	Valentina_Giunchiglia	ERR525874
-SID367_4M	SID367	stool	no	control	healthy	NA	131	newborn	male	SWE	no	128	25974306	41432790	4123700820	80	100	IlluminaHiSeq	no	26	child	vaginal	exclusively_breastfeeding	Valentina_Giunchiglia	ERR525873
-SID367_12M	SID367	stool	no	control	healthy	NA	378	child	male	SWE	no	375	25974306	48250028	4809736970	80	100	IlluminaHiSeq	no	26	child	vaginal	no_breastfeeding	Valentina_Giunchiglia	ERR525872
-SID367_M	SID367_mo	stool	NA	control	healthy	NA	NA	adult	female	SWE	no	NA	25974306	41008788	4085760520	80	100	IlluminaHiSeq	yes	26	mother	NA	NA	Valentina_Giunchiglia	ERR525875
+SID282_B	SID282	stool	no	control	healthy	NA	3	newborn	male	SWE	no	0	25974306	NA	NA	80	100	IlluminaHiSeq	no	26	child	vaginal	exclusively_breastfeeding	Valentina_Giunchiglia|Marisa_Metzger	ERR525838
+SID282_4M	SID282	stool	no	control	healthy	NA	131	newborn	male	SWE	no	128	25974306	NA	NA	80	100	IlluminaHiSeq	no	26	child	vaginal	exclusively_breastfeeding	Valentina_Giunchiglia|Marisa_Metzger	ERR525837
+SID282_12M	SID282	stool	no	control	healthy	NA	378	child	male	SWE	no	375	25974306	NA	NA	80	100	IlluminaHiSeq	no	26	child	vaginal	no_breastfeeding	Valentina_Giunchiglia|Marisa_Metzger	ERR525836
+SID282_M	SID282_mo	stool	NA	control	healthy	NA	NA adult	female	SWE	no	NA	25974306	NA	NA	80	100	IlluminaHiSeq	yes	26	mother	NA	NA	Valentina_Giunchiglia|Marisa_Metzger	ERR525839
 SID70_B	SID70	stool	no	control	healthy	NA	2	newborn	male	SWE	no	0	25974306	56218302	5608724010	80	100	IlluminaHiSeq	no	27	child	vaginal	exclusively_breastfeeding	Valentina_Giunchiglia	ERR526066
 SID70_4M	SID70	stool	yes	control	healthy	NA	120	newborn	male	SWE	no	118	25974306	44241624	4405307590	80	100	IlluminaHiSeq	no	27	child	vaginal	mixed_feeding	Valentina_Giunchiglia	ERR526065
 SID70_12M	SID70	stool	yes	control	healthy	NA	365	child	male	SWE	no	363	25974306	54561744	5443169430	80	100	IlluminaHiSeq	no	27	child	vaginal	no_breastfeeding	Valentina_Giunchiglia	ERR526064

--- a/inst/curated/BackhedF_2015/BackhedF_2015_metadata.tsv
+++ b/inst/curated/BackhedF_2015/BackhedF_2015_metadata.tsv
@@ -97,7 +97,7 @@ SID608_M	SID608_mo	stool	NA	control	healthy	NA	NA	adult	female	SWE	no	NA	2597430
 SID282_B	SID282	stool	no	control	healthy	NA	3	newborn	male	SWE	no	0	25974306	NA	NA	80	100	IlluminaHiSeq	no	26	child	vaginal	exclusively_breastfeeding	Valentina_Giunchiglia|Marisa_Metzger	ERR525838
 SID282_4M	SID282	stool	no	control	healthy	NA	131	newborn	male	SWE	no	128	25974306	NA	NA	80	100	IlluminaHiSeq	no	26	child	vaginal	exclusively_breastfeeding	Valentina_Giunchiglia|Marisa_Metzger	ERR525837
 SID282_12M	SID282	stool	no	control	healthy	NA	378	child	male	SWE	no	375	25974306	NA	NA	80	100	IlluminaHiSeq	no	26	child	vaginal	no_breastfeeding	Valentina_Giunchiglia|Marisa_Metzger	ERR525836
-SID282_M	SID282_mo	stool	NA	control	healthy	NA	NA adult	female	SWE	no	NA	25974306	NA	NA	80	100	IlluminaHiSeq	yes	26	mother	NA	NA	Valentina_Giunchiglia|Marisa_Metzger	ERR525839
+SID282_M	SID282_mo	stool	NA	control	healthy	NA	NA  adult	female	SWE	no	NA	25974306	NA	NA	80	100	IlluminaHiSeq	yes	26	mother	NA	NA	Valentina_Giunchiglia|Marisa_Metzger	ERR525839
 SID70_B	SID70	stool	no	control	healthy	NA	2	newborn	male	SWE	no	0	25974306	56218302	5608724010	80	100	IlluminaHiSeq	no	27	child	vaginal	exclusively_breastfeeding	Valentina_Giunchiglia	ERR526066
 SID70_4M	SID70	stool	yes	control	healthy	NA	120	newborn	male	SWE	no	118	25974306	44241624	4405307590	80	100	IlluminaHiSeq	no	27	child	vaginal	mixed_feeding	Valentina_Giunchiglia	ERR526065
 SID70_12M	SID70	stool	yes	control	healthy	NA	365	child	male	SWE	no	363	25974306	54561744	5443169430	80	100	IlluminaHiSeq	no	27	child	vaginal	no_breastfeeding	Valentina_Giunchiglia	ERR526064

--- a/inst/curated/BackhedF_2015/BackhedF_2015_metadata.tsv
+++ b/inst/curated/BackhedF_2015/BackhedF_2015_metadata.tsv
@@ -97,7 +97,7 @@ SID608_M	SID608_mo	stool	NA	control	healthy	NA	NA	adult	female	SWE	no	NA	2597430
 SID282_B	SID282	stool	no	control	healthy	NA	3	newborn	male	SWE	no	0	25974306	NA	NA	80	100	IlluminaHiSeq	no	26	child	vaginal	exclusively_breastfeeding	Valentina_Giunchiglia|Marisa_Metzger	ERR525838
 SID282_4M	SID282	stool	no	control	healthy	NA	131	newborn	male	SWE	no	128	25974306	NA	NA	80	100	IlluminaHiSeq	no	26	child	vaginal	exclusively_breastfeeding	Valentina_Giunchiglia|Marisa_Metzger	ERR525837
 SID282_12M	SID282	stool	no	control	healthy	NA	378	child	male	SWE	no	375	25974306	NA	NA	80	100	IlluminaHiSeq	no	26	child	vaginal	no_breastfeeding	Valentina_Giunchiglia|Marisa_Metzger	ERR525836
-SID282_M	SID282_mo	stool	NA	control	healthy	NA	NA  adult female	SWE	no	NA	25974306	NA	NA	80	100	IlluminaHiSeq	yes	26	mother	NA	NA	Valentina_Giunchiglia|Marisa_Metzger	ERR525839
+SID282_M	SID282_mo	stool	NA	control	healthy	NA	NA    adult   female	SWE	no	NA	25974306	NA	NA	80	100	IlluminaHiSeq	yes	26	mother	NA	NA	Valentina_Giunchiglia|Marisa_Metzger	ERR525839
 SID70_B	SID70	stool	no	control	healthy	NA	2	newborn	male	SWE	no	0	25974306	56218302	5608724010	80	100	IlluminaHiSeq	no	27	child	vaginal	exclusively_breastfeeding	Valentina_Giunchiglia	ERR526066
 SID70_4M	SID70	stool	yes	control	healthy	NA	120	newborn	male	SWE	no	118	25974306	44241624	4405307590	80	100	IlluminaHiSeq	no	27	child	vaginal	mixed_feeding	Valentina_Giunchiglia	ERR526065
 SID70_12M	SID70	stool	yes	control	healthy	NA	365	child	male	SWE	no	363	25974306	54561744	5443169430	80	100	IlluminaHiSeq	no	27	child	vaginal	no_breastfeeding	Valentina_Giunchiglia	ERR526064

--- a/inst/curated/BackhedF_2015/BackhedF_2015_metadata.tsv
+++ b/inst/curated/BackhedF_2015/BackhedF_2015_metadata.tsv
@@ -97,7 +97,7 @@ SID608_M	SID608_mo	stool	NA	control	healthy	NA	NA	adult	female	SWE	no	NA	2597430
 SID282_B	SID282	stool	no	control	healthy	NA	3	newborn	male	SWE	no	0	25974306	NA	NA	80	100	IlluminaHiSeq	no	26	child	vaginal	exclusively_breastfeeding	Valentina_Giunchiglia|Marisa_Metzger	ERR525838
 SID282_4M	SID282	stool	no	control	healthy	NA	131	newborn	male	SWE	no	128	25974306	NA	NA	80	100	IlluminaHiSeq	no	26	child	vaginal	exclusively_breastfeeding	Valentina_Giunchiglia|Marisa_Metzger	ERR525837
 SID282_12M	SID282	stool	no	control	healthy	NA	378	child	male	SWE	no	375	25974306	NA	NA	80	100	IlluminaHiSeq	no	26	child	vaginal	no_breastfeeding	Valentina_Giunchiglia|Marisa_Metzger	ERR525836
-SID282_M	SID282_mo	stool	NA	control	healthy	NA	NA adult female	SWE	no	NA	25974306	NA	NA	80	100	IlluminaHiSeq	yes	26	mother	NA	NA	Valentina_Giunchiglia|Marisa_Metzger	ERR525839
+SID282_M	SID282_mo	stool	NA	control	healthy	NA	NA  adult female	SWE	no	NA	25974306	NA	NA	80	100	IlluminaHiSeq	yes	26	mother	NA	NA	Valentina_Giunchiglia|Marisa_Metzger	ERR525839
 SID70_B	SID70	stool	no	control	healthy	NA	2	newborn	male	SWE	no	0	25974306	56218302	5608724010	80	100	IlluminaHiSeq	no	27	child	vaginal	exclusively_breastfeeding	Valentina_Giunchiglia	ERR526066
 SID70_4M	SID70	stool	yes	control	healthy	NA	120	newborn	male	SWE	no	118	25974306	44241624	4405307590	80	100	IlluminaHiSeq	no	27	child	vaginal	mixed_feeding	Valentina_Giunchiglia	ERR526065
 SID70_12M	SID70	stool	yes	control	healthy	NA	365	child	male	SWE	no	363	25974306	54561744	5443169430	80	100	IlluminaHiSeq	no	27	child	vaginal	no_breastfeeding	Valentina_Giunchiglia	ERR526064


### PR DESCRIPTION
changed SampleID, subject ID and NCBI accessing in lines 97-100 (family 26). In addition, the number_reads and number_base were set to NA, because the numbers have to be calculated from raw data.